### PR TITLE
M5Unified port

### DIFF
--- a/src/CallbackMenuItem.cpp
+++ b/src/CallbackMenuItem.cpp
@@ -2,7 +2,11 @@
 
 #include "Menu.h"
 
+#ifdef M5_UNIFIED
 #include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 CallbackMenuItem::CallbackMenuItem(Layout& layout_, String text_, CallbackFunction callbackOneTimeFunction_, CallbackFunction callbackLoopFunction_) : MenuItem(layout_, text_)
 {

--- a/src/CallbackMenuItem.cpp
+++ b/src/CallbackMenuItem.cpp
@@ -2,11 +2,7 @@
 
 #include "Menu.h"
 
-#ifdef M5_UNIFIED
 #include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
 
 CallbackMenuItem::CallbackMenuItem(Layout& layout_, String text_, CallbackFunction callbackOneTimeFunction_, CallbackFunction callbackLoopFunction_) : MenuItem(layout_, text_)
 {

--- a/src/CallbackMenuItem.cpp
+++ b/src/CallbackMenuItem.cpp
@@ -2,7 +2,7 @@
 
 #include "Menu.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h>
 
 CallbackMenuItem::CallbackMenuItem(Layout& layout_, String text_, CallbackFunction callbackOneTimeFunction_, CallbackFunction callbackLoopFunction_) : MenuItem(layout_, text_)
 {

--- a/src/DownSoftKey.cpp
+++ b/src/DownSoftKey.cpp
@@ -1,10 +1,6 @@
 #include "DownSoftKey.h"
 
-#ifdef M5_UNIFIED
 #include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
 
 
 DownSoftKey::DownSoftKey(SoftKeySlot slot_, Layout& layout_) : SoftKey(slot_, layout_)

--- a/src/DownSoftKey.cpp
+++ b/src/DownSoftKey.cpp
@@ -1,6 +1,6 @@
 #include "DownSoftKey.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h>
 
 
 DownSoftKey::DownSoftKey(SoftKeySlot slot_, Layout& layout_) : SoftKey(slot_, layout_)

--- a/src/DownSoftKey.cpp
+++ b/src/DownSoftKey.cpp
@@ -1,6 +1,10 @@
 #include "DownSoftKey.h"
 
+#ifdef M5_UNIFIED
 #include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 
 DownSoftKey::DownSoftKey(SoftKeySlot slot_, Layout& layout_) : SoftKey(slot_, layout_)

--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -1,16 +1,17 @@
 #include "Layout.h"
 
-#include <M5Unified.h> 
+#ifdef M5_UNIFIED
+#include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 
 Layout::Layout()
 {
 	// General
-	// TODO: Find out why M5 library is not passing the values
-	SCREEN_WIDTH = 320;
-	SCREEN_HEIGHT = 240;
-	//SCREEN_WIDTH = M5.Lcd.width();
-	//SCREEN_HEIGHT = M5.Lcd.height();
+	SCREEN_WIDTH = M5.Display.width();
+	SCREEN_HEIGHT = M5.Display.height();
 	MENU_FONT = 2;
 	MENU_FONT_SIZE = 2;
 

--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -6,8 +6,11 @@
 Layout::Layout()
 {
 	// General
-	SCREEN_WIDTH = M5.Lcd.height();
-	SCREEN_HEIGHT = M5.Lcd.width();
+	// TODO: Find out why M5 library is not passing the values
+	SCREEN_WIDTH = 320;
+	SCREEN_HEIGHT = 240;
+	//SCREEN_WIDTH = M5.Lcd.width();
+	//SCREEN_HEIGHT = M5.Lcd.height();
 	MENU_FONT = 2;
 	MENU_FONT_SIZE = 2;
 

--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -6,11 +6,8 @@
 Layout::Layout()
 {
 	// General
-	// TODO: Find out why M5 library is not passing the values
-	SCREEN_WIDTH = 320;
-	SCREEN_HEIGHT = 240;
-	//SCREEN_WIDTH = M5.Lcd.width();
-	//SCREEN_HEIGHT = M5.Lcd.height();
+	SCREEN_WIDTH = M5.Lcd.width();
+	SCREEN_HEIGHT = M5.Lcd.height();
 	MENU_FONT = 2;
 	MENU_FONT_SIZE = 2;
 

--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -1,17 +1,16 @@
 #include "Layout.h"
 
-#ifdef M5_UNIFIED
-#include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
+#include <M5Unified.h> 
 
 
 Layout::Layout()
 {
 	// General
-	SCREEN_WIDTH = M5.Display.width();
-	SCREEN_HEIGHT = M5.Display.height();
+	// TODO: Find out why M5 library is not passing the values
+	SCREEN_WIDTH = 320;
+	SCREEN_HEIGHT = 240;
+	//SCREEN_WIDTH = M5.Lcd.width();
+	//SCREEN_HEIGHT = M5.Lcd.height();
 	MENU_FONT = 2;
 	MENU_FONT_SIZE = 2;
 

--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -1,6 +1,6 @@
 #include "Layout.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h> 
 
 
 Layout::Layout()

--- a/src/M5StackMenuSystem.h
+++ b/src/M5StackMenuSystem.h
@@ -1,6 +1,8 @@
 #ifndef M5_STACK_MENU_SYSTEM_H
 #define M5_STACK_MENU_SYSTEM_H
 
+#define M5_UNIFIED
+
 #include "Menu.h"
 #include "TextSoftKey.h"
 #include "UpSoftKey.h"

--- a/src/M5StackMenuSystem.h
+++ b/src/M5StackMenuSystem.h
@@ -1,8 +1,6 @@
 #ifndef M5_STACK_MENU_SYSTEM_H
 #define M5_STACK_MENU_SYSTEM_H
 
-#define M5_UNIFIED
-
 #include "Menu.h"
 #include "TextSoftKey.h"
 #include "UpSoftKey.h"

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -3,7 +3,7 @@
 #include "SubMenuItem.h"
 #include "MenuExitItem.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h>
 
 Menu::Menu(String title_) : menuTopSection(layout, title_), menuBottomSection(layout, this)
 {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -3,11 +3,7 @@
 #include "SubMenuItem.h"
 #include "MenuExitItem.h"
 
-#ifdef M5_UNIFIED
 #include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
 
 Menu::Menu(String title_) : menuTopSection(layout, title_), menuBottomSection(layout, this)
 {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -3,7 +3,11 @@
 #include "SubMenuItem.h"
 #include "MenuExitItem.h"
 
+#ifdef M5_UNIFIED
 #include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 Menu::Menu(String title_) : menuTopSection(layout, title_), menuBottomSection(layout, this)
 {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -43,6 +43,11 @@ bool Menu::isEnabled()
 	return enabled;
 }
 
+bool Menu::isDirty()
+{
+	return dirty;
+}
+
 void Menu::reset()
 {
 	firstItemInViewport = firstItem;

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -28,6 +28,8 @@ public:
 	
 	/* Check if the menu is currently enabled*/
 	bool isEnabled();
+
+	/* Check if the menu is current dirty */
 	bool isDirty();
 	
 	/* Reset the highlighted menu item to the first one*/

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -28,6 +28,8 @@ public:
 	
 	/* Check if the menu is currently enabled*/
 	bool isEnabled();
+
+	/* Check if the menu is currently dirty */
 	bool isDirty();
 	
 	/* Reset the highlighted menu item to the first one*/

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -28,6 +28,7 @@ public:
 	
 	/* Check if the menu is currently enabled*/
 	bool isEnabled();
+	bool isDirty();
 	
 	/* Reset the highlighted menu item to the first one*/
 	void reset();

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -28,8 +28,6 @@ public:
 	
 	/* Check if the menu is currently enabled*/
 	bool isEnabled();
-
-	/* Check if the menu is currently dirty */
 	bool isDirty();
 	
 	/* Reset the highlighted menu item to the first one*/

--- a/src/MenuBottomSection.cpp
+++ b/src/MenuBottomSection.cpp
@@ -2,11 +2,7 @@
 
 #include "Menu.h"
 
-#ifdef M5_UNIFIED
 #include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
 
 MenuBottomSection::MenuBottomSection(Layout& layout_, Menu* menu_) : layout(layout_), softKeyUp(BtnASlot, layout_), softKeyDown(BtnBSlot, layout_), softKeyOk(BtnCSlot, layout_, "Ok")
 {

--- a/src/MenuBottomSection.cpp
+++ b/src/MenuBottomSection.cpp
@@ -2,7 +2,7 @@
 
 #include "Menu.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h>
 
 MenuBottomSection::MenuBottomSection(Layout& layout_, Menu* menu_) : layout(layout_), softKeyUp(BtnASlot, layout_), softKeyDown(BtnBSlot, layout_), softKeyOk(BtnCSlot, layout_, "Ok")
 {

--- a/src/MenuBottomSection.cpp
+++ b/src/MenuBottomSection.cpp
@@ -2,7 +2,11 @@
 
 #include "Menu.h"
 
+#ifdef M5_UNIFIED
 #include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 MenuBottomSection::MenuBottomSection(Layout& layout_, Menu* menu_) : layout(layout_), softKeyUp(BtnASlot, layout_), softKeyDown(BtnBSlot, layout_), softKeyOk(BtnCSlot, layout_, "Ok")
 {

--- a/src/MenuExitItem.cpp
+++ b/src/MenuExitItem.cpp
@@ -2,11 +2,7 @@
 
 #include "Menu.h"
 
-#ifdef M5_UNIFIED
 #include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
 
 MenuExitItem::MenuExitItem(Layout& layout_, Menu* parentMenu_) : MenuItem(layout_, "..")
 {

--- a/src/MenuExitItem.cpp
+++ b/src/MenuExitItem.cpp
@@ -2,7 +2,11 @@
 
 #include "Menu.h"
 
+#ifdef M5_UNIFIED
 #include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 MenuExitItem::MenuExitItem(Layout& layout_, Menu* parentMenu_) : MenuItem(layout_, "..")
 {

--- a/src/MenuExitItem.cpp
+++ b/src/MenuExitItem.cpp
@@ -2,7 +2,7 @@
 
 #include "Menu.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h>
 
 MenuExitItem::MenuExitItem(Layout& layout_, Menu* parentMenu_) : MenuItem(layout_, "..")
 {

--- a/src/MenuItem.cpp
+++ b/src/MenuItem.cpp
@@ -2,7 +2,11 @@
 
 #include "Menu.h"
 
+#ifdef M5_UNIFIED
 #include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 
 MenuItem::MenuItem(Layout& layout_, String text_) : layout(layout_)

--- a/src/MenuItem.cpp
+++ b/src/MenuItem.cpp
@@ -2,7 +2,7 @@
 
 #include "Menu.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h>
 
 
 MenuItem::MenuItem(Layout& layout_, String text_) : layout(layout_)

--- a/src/MenuItem.cpp
+++ b/src/MenuItem.cpp
@@ -2,11 +2,7 @@
 
 #include "Menu.h"
 
-#ifdef M5_UNIFIED
 #include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
 
 
 MenuItem::MenuItem(Layout& layout_, String text_) : layout(layout_)

--- a/src/MenuTopSection.cpp
+++ b/src/MenuTopSection.cpp
@@ -1,10 +1,6 @@
 #include "MenuTopSection.h"
 
-#ifdef M5_UNIFIED
 #include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
 
 MenuTopSection::MenuTopSection(Layout& layout_, String title_) : layout(layout_)
 {

--- a/src/MenuTopSection.cpp
+++ b/src/MenuTopSection.cpp
@@ -1,6 +1,10 @@
 #include "MenuTopSection.h"
 
+#ifdef M5_UNIFIED
 #include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 MenuTopSection::MenuTopSection(Layout& layout_, String title_) : layout(layout_)
 {

--- a/src/MenuTopSection.cpp
+++ b/src/MenuTopSection.cpp
@@ -1,6 +1,6 @@
 #include "MenuTopSection.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h>
 
 MenuTopSection::MenuTopSection(Layout& layout_, String title_) : layout(layout_)
 {

--- a/src/SoftKey.cpp
+++ b/src/SoftKey.cpp
@@ -1,6 +1,6 @@
 #include "SoftKey.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h>
 
 SoftKey::SoftKey(SoftKeySlot slot_, Layout& layout_) : layout(layout_)
 {

--- a/src/SoftKey.cpp
+++ b/src/SoftKey.cpp
@@ -1,10 +1,6 @@
 #include "SoftKey.h"
 
-#ifdef M5_UNIFIED
 #include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
 
 SoftKey::SoftKey(SoftKeySlot slot_, Layout& layout_) : layout(layout_)
 {

--- a/src/SoftKey.cpp
+++ b/src/SoftKey.cpp
@@ -1,6 +1,10 @@
 #include "SoftKey.h"
 
+#ifdef M5_UNIFIED
 #include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 SoftKey::SoftKey(SoftKeySlot slot_, Layout& layout_) : layout(layout_)
 {

--- a/src/SubMenuItem.cpp
+++ b/src/SubMenuItem.cpp
@@ -2,7 +2,11 @@
 
 #include "Menu.h"
 
+#ifdef M5_UNIFIED
 #include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 SubMenuItem::SubMenuItem(Layout& layout_, String text_, Menu* subMenu_) : MenuItem(layout_, text_)
 {

--- a/src/SubMenuItem.cpp
+++ b/src/SubMenuItem.cpp
@@ -2,11 +2,7 @@
 
 #include "Menu.h"
 
-#ifdef M5_UNIFIED
 #include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
 
 SubMenuItem::SubMenuItem(Layout& layout_, String text_, Menu* subMenu_) : MenuItem(layout_, text_)
 {

--- a/src/SubMenuItem.cpp
+++ b/src/SubMenuItem.cpp
@@ -2,7 +2,7 @@
 
 #include "Menu.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h>
 
 SubMenuItem::SubMenuItem(Layout& layout_, String text_, Menu* subMenu_) : MenuItem(layout_, text_)
 {

--- a/src/SubMenuItem.cpp
+++ b/src/SubMenuItem.cpp
@@ -11,7 +11,9 @@ SubMenuItem::SubMenuItem(Layout& layout_, String text_, Menu* subMenu_) : MenuIt
 
 void SubMenuItem::loop() 
 {
-	subMenu->enable();
+	if (subMenu->isDirty()) {
+		subMenu->enable();
+	}
 	subMenu->loop();
 }
 

--- a/src/TextSoftKey.cpp
+++ b/src/TextSoftKey.cpp
@@ -1,6 +1,6 @@
 #include "TextSoftKey.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h>
 
 
 TextSoftKey::TextSoftKey(SoftKeySlot slot_, Layout& layout_, String text_) : SoftKey(slot_, layout_)

--- a/src/TextSoftKey.cpp
+++ b/src/TextSoftKey.cpp
@@ -1,10 +1,6 @@
 #include "TextSoftKey.h"
 
-#ifdef M5_UNIFIED
 #include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
 
 
 TextSoftKey::TextSoftKey(SoftKeySlot slot_, Layout& layout_, String text_) : SoftKey(slot_, layout_)

--- a/src/TextSoftKey.cpp
+++ b/src/TextSoftKey.cpp
@@ -1,6 +1,10 @@
 #include "TextSoftKey.h"
 
+#ifdef M5_UNIFIED
 #include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 
 TextSoftKey::TextSoftKey(SoftKeySlot slot_, Layout& layout_, String text_) : SoftKey(slot_, layout_)

--- a/src/UpSoftKey.cpp
+++ b/src/UpSoftKey.cpp
@@ -1,10 +1,6 @@
 #include "UpSoftKey.h"
 
-#ifdef M5_UNIFIED
 #include <M5Unified.h>
-#else
-#include <M5Stack.h>
-#endif
 
 
 UpSoftKey::UpSoftKey(SoftKeySlot slot_, Layout& layout_) : SoftKey(slot_, layout_)

--- a/src/UpSoftKey.cpp
+++ b/src/UpSoftKey.cpp
@@ -1,6 +1,10 @@
 #include "UpSoftKey.h"
 
+#ifdef M5_UNIFIED
 #include <M5Unified.h>
+#else
+#include <M5Stack.h>
+#endif
 
 
 UpSoftKey::UpSoftKey(SoftKeySlot slot_, Layout& layout_) : SoftKey(slot_, layout_)

--- a/src/UpSoftKey.cpp
+++ b/src/UpSoftKey.cpp
@@ -1,6 +1,6 @@
 #include "UpSoftKey.h"
 
-#include <M5Stack.h>
+#include <M5Unified.h>
 
 
 UpSoftKey::UpSoftKey(SoftKeySlot slot_, Layout& layout_) : SoftKey(slot_, layout_)


### PR DESCRIPTION
I have been porting this library over to the M5Unified library instead of M5Stack in order to support a project I am working on.  At the moment it runs on an `M5Stack Core2 v1.1` with one issue in detecting the width/height inside of Layout.cpp.  This can be resolved by customizing the menu in the user code.

Please let me know if there are any issues with this approach.  Thanks!

```
Menu mainMenu("Main Menu");
customizeLayout(mainMenu.getLayout());
void customizeLayout(Layout& layout) {
    layout.SCREEN_WIDTH = M5.Display.width();
    layout.SCREEN_HEIGHT = M5.Display.height();
}
```